### PR TITLE
Add option to automatically split long lines

### DIFF
--- a/control.html
+++ b/control.html
@@ -37,7 +37,7 @@
                 </div>
             </div>
             <div class="floating">
-                <div class="control-group"><input id="auto-update-checkbox" type="checkbox"><label for="auto-show-checkbox">Auto-update text on slide change</label></div>
+                <div class="control-group"><input id="auto-update-checkbox" type="checkbox"><label for="auto-update-checkbox">Auto-update text on slide change</label></div>
                 <div class="control-group"><input id="display-all-checkbox" type="checkbox"><label for="display-all-checkbox">Display all text</label></div>
                 <div class="control-group"><input id="auto-hide-checkbox" type="checkbox"><label for="auto-hide-checkbox">Auto-hide when blank screen displayed</label></div>
                 <div class="control-group"><input id="resize-checkbox" type="checkbox"><label for="resize-checkbox">Resize text that doesn't fit in window</label></div>

--- a/control.html
+++ b/control.html
@@ -37,7 +37,7 @@
                 </div>
             </div>
             <div class="floating">
-                <div class="control-group"><input id="auto-update-checkbox" type="checkbox"><label for="auto-update-checkbox">Auto-update text on slide change</label></div>
+                <div class="control-group"><input id="auto-update-checkbox" type="checkbox"><label for="auto-show-checkbox">Auto-update text on slide change</label></div>
                 <div class="control-group"><input id="display-all-checkbox" type="checkbox"><label for="display-all-checkbox">Display all text</label></div>
                 <div class="control-group"><input id="auto-hide-checkbox" type="checkbox"><label for="auto-hide-checkbox">Auto-hide when blank screen displayed</label></div>
                 <div class="control-group"><input id="resize-checkbox" type="checkbox"><label for="resize-checkbox">Resize text that doesn't fit in window</label></div>

--- a/control.html
+++ b/control.html
@@ -62,6 +62,24 @@
                     <input id="control-font-size-spinner" type="number" min="9" max="36" step="1" value="9" size="2">
                 </div>
                 <div class="control-group">
+                    <div class="control-group">
+                        <input id="auto-split-long-lines-checkbox" type="checkbox" checked="true">
+                        <label for="auto-split-long-lines-checkbox">Automatically split long lines</label>
+                    </div>
+                    <div class="control-group" id="split-max-characters">
+                        <label for="split-max-characters-spinner">Maximum characters per line</label><br>
+                        <input id="split-max-characters-spinner" type="number" min="10" max="100" step="1" value="60" size="3">
+                    </div>
+                    <div class="control-group" id="split-min-words">
+                        <label for="split-min-words-spinner">Minimum words per line</label><br>
+                        <input id="split-min-words-spinner" type="number" min="1" max="10" step="1" value="3" size="2">
+                    </div>
+                </div>
+                <div class="control-group">
+                    <input id="superscripted-verse-numbers-checkbox" type="checkbox" checked="true">
+                    <label for="superscripted-verse-numbers-checkbox">Small verse numbers</label>
+                </div>
+                <div class="control-group">
                     <span>Lyrics font size</span><br>
                     <input id="lyrics-font-size-spinner" type="number" min="0" max="128" step="1" value="36" size="2">
                 </div>

--- a/stage.js
+++ b/stage.js
@@ -72,7 +72,16 @@ window.OpenLP = {
         if (slide["title"]) {
             text = slide["title"];
         } else {
-            text = slide["text"];
+            if (superscriptedVerseNumbers) {
+                text = slide["html"]
+                    .replace("[","&#91;")
+                    .replace("]","&#92;")
+                    .replace(RegExp('/<(\/?)sup>/[\1sup]/gi'))
+                    .replace(RegExp('/<\/?[^>]+>//gi'))
+                    .replace(RegExp('/\[(\/?)sup\]/<\1sup>/gi'));
+            } else {
+                text = slide["text"];
+            }
         }
         //text = text.replace(/\n/g, "<br />");
         obsChannel.postMessage(JSON.stringify({type: "lyrics", lines: text.split(/\n/g)}));
@@ -128,6 +137,8 @@ window.OpenLP = {
         } else if (data.type === "font") {
             defaultFont = data.value;
             updateLayout = true;
+        } else if (data.type === "superscriptedVerseNumbers") {
+            superscriptedVerseNumbers = data.value;
         } else if (data.type === "nextSlide") {
             $.get("/api/controller/live/next");
         } else if (data.type === "previousSlide") {
@@ -179,6 +190,7 @@ var alwaysHide = false;
 var fadeDuration = 900;
 
 var autoResize = false;
+var superscriptedVerseNumbers = true;
 var defaultFont = 36;
 
 obsChannel.onmessage = OpenLP.channelReceive;


### PR DESCRIPTION
Because OpenLP sends verses from Bible sources with one verse per line, these "lines" end up wrapping several times when displayed in OBS. This change gives options to cap line length to a certain number of characters while also maintaining a minimum number of words per line. Also included is an option to show chapter and verse numbers superscripted.

Although I've been hacking on open source projects for many years, this is the first project I'm actually contributing to. Please let me know if I need to do anything differently. Thanks!