### PR TITLE
Bugfix: small versenumbers

### DIFF
--- a/control.js
+++ b/control.js
@@ -65,11 +65,12 @@ function splitLines(text) {
 
     if (text === undefined)
         return "";
-
+    
+    // Don't split in the middle of HTML tag definitions
+    var characters = Array.from(text);
     var newText = '';
     var inTag = false;
-    // Don't split in the middle of HTML tag definitions
-    $.each(text.split(), function(idx, char) {
+    $.each(characters, function(idx, char) {
         if (char == ' ' && !inTag) {
             newText += '__SPACE__';
         } else {
@@ -81,23 +82,21 @@ function splitLines(text) {
             newText += char;
         }
     });
-    var words = text = newText.split('__SPACE__');
+    var words = newText.split('__SPACE__');
+
     var lines = Array();
     var lineWords = Array();
-    // We need to keep a length of the line that doesn't include any tags
+    // Length of the line, not including any tags
     var lineWordsLength = 0;
 
     // Create the lines of words within the character constraint
     for (var i = 0; i < words.length; i++) {
-        let newWord = Array(words[i]);
+        let wordLength = words[i].replace(/<[^>]+>/g, '').length;
 
-        // Don't count HTML tags in overall word length
-        let wordLength = newWord.replace(/<[^>]+>/gi, '').length;
-
-        // Add at least one word per line; otherwise no more words than allowed by maxCharactersr
+        // Add at least one word per line; otherwise no more words than allowed by maxCharacters
         if (lineWords.length > 1 && lineWordsLength + 1 + wordLength > maxCharacters) {
             lines.push(lineWords);
-            lineWords = newWord;
+            lineWords = Array(words[i]);
             lineWordsLength = wordLength;
         } else {
             lineWords.push(words[i]);
@@ -106,8 +105,8 @@ function splitLines(text) {
     }
     lines.push(lineWords);
 
-    var shifted = true;
     // Work backwards to ensure we have enough words per line
+    var shifted = true;
     for (i = lines.length - 1; i > 1 && shifted; i--) {
         var shifted = false;
         while (lines[i].length < minWords) {
@@ -120,7 +119,7 @@ function splitLines(text) {
 
             newWord = lines[i - 1][lines[i - 1].length - 1];
 
-            if (lines[i].join(" ").replace(/<[^>]+>/gi, '').length + newWord.replace(/<[^>]+>/gi, '').length + 1 < maxCharacters) {
+            if (lines[i].join(" ").replace(/<[^>]+>/g, '').length + newWord.replace(/<[^>]+>/g, '').length + 1 < maxCharacters) {
                 lines[i].unshift(lines[i - 1].pop());
                 shifted = true;
             } else {

--- a/control.js
+++ b/control.js
@@ -66,42 +66,61 @@ function splitLines(text) {
     if (text === undefined)
         return "";
 
-    var words = text.split(" ");
+    var newText = '';
+    var inTag = false;
+    // Don't split in the middle of HTML tag definitions
+    $.each(text.split(), function(idx, char) {
+        if (char == ' ' && !inTag) {
+            newText += '__SPACE__';
+        } else {
+            if (char == '<') {
+                inTag = true;
+            } else if (char == '>') {
+                inTag = false;
+            }
+            newText += char;
+        }
+    });
+    var words = text = newText.split('__SPACE__');
     var lines = Array();
-    var line_words = Array();
-
+    var lineWords = Array();
+    // We need to keep a length of the line that doesn't include any tags
+    var lineWordsLength = 0;
 
     // Create the lines of words within the character constraint
     for (var i = 0; i < words.length; i++) {
-        new_word = Array(words[i]);
+        let newWord = Array(words[i]);
+
+        // Don't count HTML tags in overall word length
+        let wordLength = newWord.replace(/<[^>]+>/gi, '').length;
 
         // Add at least one word per line; otherwise no more words than allowed by maxCharactersr
-        if (line_words.length > 1 && line_words.concat(new_word).join(" ").length > maxCharacters) {
-            lines.push(line_words);
-            line_words = new_word;
+        if (lineWords.length > 1 && lineWordsLength + 1 + wordLength > maxCharacters) {
+            lines.push(lineWords);
+            lineWords = newWord;
+            lineWordsLength = wordLength;
         } else {
-            line_words.push(words[i]);
+            lineWords.push(words[i]);
+            lineWordsLength += 1 + wordLength;
         }
     }
-    lines.push(line_words);
+    lines.push(lineWords);
 
     var shifted = true;
     // Work backwards to ensure we have enough words per line
     for (i = lines.length - 1; i > 1 && shifted; i--) {
-        console.log("i: %s\nline: %s", i, lines[i].join("/"))
         var shifted = false;
         while (lines[i].length < minWords) {
             if (lines[i - 1].length == 0) {
-                window.alert("found an empty line!")
                 lines.splice(i - 1, 1);
                 i--;
                 if (i < 1)
                     break;
             }
 
-            new_word = lines[i - 1][lines[i - 1].length - 1];
+            newWord = lines[i - 1][lines[i - 1].length - 1];
 
-            if (lines[i].join(" ").length + new_word.length + 1 < maxCharacters) {
+            if (lines[i].join(" ").replace(/<[^>]+>/gi, '').length + newWord.replace(/<[^>]+>/gi, '').length + 1 < maxCharacters) {
                 lines[i].unshift(lines[i - 1].pop());
                 shifted = true;
             } else {
@@ -111,12 +130,12 @@ function splitLines(text) {
     }
 
 
-    var lines_of_words = Array();
+    var linesOfWords = Array();
     for (i = 0; i < lines.length; i++) {
-        lines_of_words.push(lines[i].join(" "));
+        linesOfWords.push(lines[i].join(" "));
     }
 
-    return lines_of_words.join("\n");
+    return linesOfWords.join("\n");
 }
 
 function displayNext(amount) {

--- a/stage.js
+++ b/stage.js
@@ -185,7 +185,7 @@ window.OpenLP = {
             }
         }
     },
-    filterTags: function(string, tags) {
+    filterTags: function (string, tags) {
         string = string
             // <br> comes through. Change to \n to preserve them and make line-counting accurate
             .replace(/<br>/gi, "\n")
@@ -200,7 +200,7 @@ window.OpenLP = {
 
         string = string
             // remove remaining HTML tags
-            .replace(/<\/?[^>]+>/gi, '')
+            .replace(/<[^>]+>/g, '')
             // restore the tags we preserved
             .replace(/\[(\/?)([^\]]+)\]/gi, '<$1$2>');
 

--- a/stage.js
+++ b/stage.js
@@ -73,12 +73,7 @@ window.OpenLP = {
             text = slide["title"];
         } else {
             if (superscriptedVerseNumbers) {
-                text = slide["html"]
-                        //.replace("[","&#91;")
-                        //.replace("]","&#92;")
-                        .replace(RegExp('/<(\/?)sup>/[\1sup]/gi'))
-                        .replace(RegExp('/<\/?[^>]+>//gi'))
-                        .replace(RegExp('/\[(\/?)sup\]/<\1sup>/gi'));
+                text = OpenLP.filterTags(slide["html"], new Array('sup'));
             } else {
                 text = slide["text"];
             }
@@ -189,6 +184,27 @@ window.OpenLP = {
                 }
             }
         }
+    },
+    filterTags: function(string, tags) {
+        string = string
+            // <br> comes through. Change to \n to preserve them and make line-counting accurate
+            .replace(/<br>/gi, "\n")
+            // If we find square brackets in the text, assume the user intends them to be
+            // those literal characters and replace with their respective HTML entities
+            .replace(/\[/g, "&#91;")
+            .replace(/\]/g, "&#93;");
+
+        $.each(tags, function(idx, tag) {
+            string = string.replace(new RegExp('<(\/?)'+tag+'([^>]*)>', 'gi'), '[$1'+tag+'$2]');
+        });
+
+        string = string
+            // remove remaining HTML tags
+            .replace(/<\/?[^>]+>/gi, '')
+            // restore the tags we preserved
+            .replace(/\[(\/?)([^\]]+)\]/gi, '<$1$2>');
+
+        return string;
     }
 }
 $.ajaxSetup({cache: false});


### PR DESCRIPTION
The replace() functions were not doing replacements correctly, which was throwing off line counting. This fixes that error and also paves the way to allow more HTML tags to come through from OpenLP (c.f. [Issue 11](https://github.com/amirchev/OBS-OpenLP-Lyrics-Interface/issues/11)).